### PR TITLE
Fix field label title

### DIFF
--- a/code/EditableRecaptchaField.php
+++ b/code/EditableRecaptchaField.php
@@ -9,7 +9,7 @@ if(class_exists('EditableFormField')) {
         private static $plural_name = 'reCAPTCHA Fields';
 
         public function getFormField() {
-            return RecaptchaField::create($this->Name);
+            return RecaptchaField::create($this->Name, $this->EscapedTitle);
         }
 
         public function getRequired() {


### PR DESCRIPTION
EditableFormField uses `$this->EscapedTitle` to populate the field label
